### PR TITLE
Dev metadata check

### DIFF
--- a/dspaceq/tasks/utils.py
+++ b/dspaceq/tasks/utils.py
@@ -118,7 +118,7 @@ def missing_fields(bib_record):
         "260/264: Publish Year": "record/datafield[@tag=264]|record/datafield[@tag=260]",
         "502: Thesis/Diss Tag": "record/datafield[@tag=502]",
         "690: School": "record/datafield[@tag=690]",
-        "650/651/630/610: Subject Heading": "record/datafield[@tag=650]|record/datafield[@tag=651]|record/datafield[@tag=610]|record/datafield[@tag=630]"
+        "600/610/611/630/650/651: Subject Heading": "record/datafield[@tag=600]|record/datafield[@tag=610]|record/datafield[@tag=611]|record/datafield[@tag=630]|record/datafield[@tag=650]|record/datafield[@tag=651]"
     }
     if bib_record is not None and type(bib_record) is not dict:
         root = etree.fromstring(bib_record)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 #ez_setup.use_setuptools()
 from setuptools import setup, find_packages
 setup(name='dspaceq',
-      version='0.0.272',
+      version='0.0.273',
       packages= find_packages(),
       package_data={'dspaceq':['tasks/xslt/*']},
       install_requires=[


### PR DESCRIPTION
This updates the xpaths for subject tags used to check for missing metadata.
Successfully tested change in subject tags with current digitized requests. 